### PR TITLE
Suggestion: Use http_archive instead of git_repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ Follow these instructions strictly.
 ```
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
-git_repository(
+http_archive(
     name = "golink",
-    commit = "v1.0.0",
-    remote = "https://github.com/nikunjy/golink",
+    urls = ["https://github.com/nikunjy/golink/archive/v1.0.0.tar.gz"],
+    sha256 = "ea728cfc9cb6e2ae024e1d5fbff185224592bbd4dad6516f3cc96d5155b69f0d",
+    strip_prefix = "golink-1.0.0",
 )
 ```
 


### PR DESCRIPTION
This is a tiny PR to use http_archive instead of git_repository, since they are significantly faster as repo size grows and github automatically creates nice archives when a new tag is released anyway :)