### PR TITLE
Pass all file deps as runfiles to copy script

### DIFF
--- a/golink.bzl
+++ b/golink.bzl
@@ -15,7 +15,7 @@ def gen_copy_files_script(ctx, files):
         substitutions = substitutions,
         is_executable = True,
     )
-    runfiles = ctx.runfiles(files = [files[0]])
+    runfiles = ctx.runfiles(files = files)
     return [
         DefaultInfo(
             files = depset([out]),


### PR DESCRIPTION
currently the runfiles of the copy script only contains the first
dependency file, which causes a file not found if a dependency target has multiple
output files to copy. This makes sure all files are available to the script